### PR TITLE
Enable Aptly repo on clients

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures ele-apt'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.1'
+version '0.2.2'
 
 recipe 'ele-apt', 'Installs ele apt repo'
 recipe 'repo', 'Installs Aptly package repository'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,3 +15,11 @@ apt_repository 'intapt' do
   key 'intapt.key'
   action :add
 end
+
+apt_repository 'aptly' do
+  uri 'http://apt.cm.k1k.me/'
+  distribution node['lsb']['codename']
+  components ['main']
+  key 'aptly.key'
+  action :add
+end


### PR DESCRIPTION
# TODO
- [x] dns CNAME `apt.cm.k1k.me` points to `bb0`
- [ ] generate `aptly.key`
- [ ] ensure apache/aptly is listening
